### PR TITLE
Fixed handling for transaction

### DIFF
--- a/Sources/InAppPurchase.swift
+++ b/Sources/InAppPurchase.swift
@@ -64,14 +64,13 @@ extension InAppPurchase: InAppPurchaseProvidable {
     }
 
     public func set(shouldAddStorePaymentHandler: ((_ product: Product) -> Bool)? = nil, handler: InAppPurchase.PurchaseHandler?) {
-        paymentProvider.set(shouldAddStorePaymentHandler: { [weak self] (queue, payment, product) -> Bool in
+        paymentProvider.set(shouldAddStorePaymentHandler: { [weak self] (_, payment, product) -> Bool in
             let shouldAddStorePayment = shouldAddStorePaymentHandler?(Internal.Product(product)) ?? false
             if shouldAddStorePayment {
-                self?.paymentProvider.addPaymentHandler(withProductIdentifier: payment.productIdentifier, handler: { (queue, result) in
+                self?.paymentProvider.addPaymentHandler(withProductIdentifier: payment.productIdentifier, handler: { (_, result) in
                     switch result {
                     case .success(let transaction):
                         InAppPurchase.handle(
-                            queue: queue,
                             transaction: transaction,
                             handler: handler
                         )
@@ -127,11 +126,10 @@ extension InAppPurchase: InAppPurchaseProvidable {
 
                 // Add payment to App Store queue
                 let payment = SKPayment(product: product)
-                self?.paymentProvider.add(payment: payment, handler: { (queue, result) in
+                self?.paymentProvider.add(payment: payment, handler: { (_, result) in
                     switch result {
                     case .success(let transaction):
                         InAppPurchase.handle(
-                            queue: queue,
                             transaction: transaction,
                             handler: handler
                         )

--- a/Sources/Internal/Internal+InAppPurchase.swift
+++ b/Sources/Internal/Internal+InAppPurchase.swift
@@ -54,7 +54,7 @@ extension InAppPurchase {
         let fallbackHandler: PaymentHandler = { (_, result) in
             switch result {
             case .success(let transaction):
-                handler?(.success(.purchased(transaction: Internal.PaymentTransaction(transaction))))
+                handle(transaction: transaction, handler: handler)
             case .failure(let error):
                 handler?(.failure(error))
             }
@@ -62,7 +62,7 @@ extension InAppPurchase {
         return fallbackHandler
     }
 
-    internal static func handle(queue: SKPaymentQueue, transaction: SKPaymentTransaction, handler: InAppPurchase.PurchaseHandler?) {
+    internal static func handle(transaction: SKPaymentTransaction, handler: InAppPurchase.PurchaseHandler?) {
         switch transaction.transactionState {
         case .purchasing:
             // Do nothing

--- a/Tests/InAppPurchaseTests.swift
+++ b/Tests/InAppPurchaseTests.swift
@@ -456,7 +456,6 @@ class InAppPurchaseTests: XCTestCase {
     }
 
     func testHandleWherePurchasing() {
-        let queue = StubPaymentQueue()
         let payment = StubPayment(productIdentifier: "PRODUCT_001")
         let transaction = StubPaymentTransaction(
             transactionIdentifier: "TRANSACTION_001",
@@ -464,13 +463,12 @@ class InAppPurchaseTests: XCTestCase {
             payment: payment
         )
 
-        InAppPurchase.handle(queue: queue, transaction: transaction, handler: { _ in
+        InAppPurchase.handle(transaction: transaction, handler: { _ in
             XCTFail()
         })
     }
 
     func testHandleWherePurchased() {
-        let queue = StubPaymentQueue()
         let payment = StubPayment(productIdentifier: "PRODUCT_001")
         let originalTransaction = StubPaymentTransaction(
             transactionIdentifier: "ORIGINAL_TRANSACTION_001",
@@ -485,7 +483,7 @@ class InAppPurchaseTests: XCTestCase {
         )
 
         let expectation = self.expectation()
-        InAppPurchase.handle(queue: queue, transaction: transaction, handler: { result in
+        InAppPurchase.handle(transaction: transaction, handler: { result in
             switch result {
             case .success(let state):
                 if case let .purchased(transaction) = state {
@@ -503,7 +501,6 @@ class InAppPurchaseTests: XCTestCase {
     }
 
     func testHandleWhereRestored() {
-        let queue = StubPaymentQueue()
         let payment = StubPayment(productIdentifier: "PRODUCT_001")
         let transaction = StubPaymentTransaction(
             transactionIdentifier: "TRANSACTION_001",
@@ -512,7 +509,7 @@ class InAppPurchaseTests: XCTestCase {
         )
 
         let expectation = self.expectation()
-        InAppPurchase.handle(queue: queue, transaction: transaction, handler: { result in
+        InAppPurchase.handle(transaction: transaction, handler: { result in
             switch result {
             case .success(let state):
                 XCTAssertEqual(state, .restored)
@@ -525,7 +522,6 @@ class InAppPurchaseTests: XCTestCase {
     }
 
     func testHandleWhereDeferred() {
-        let queue = StubPaymentQueue()
         let payment = StubPayment(productIdentifier: "PRODUCT_001")
         let transaction = StubPaymentTransaction(
             transactionIdentifier: "TRANSACTION_001",
@@ -534,7 +530,7 @@ class InAppPurchaseTests: XCTestCase {
         )
 
         let expectation1 = self.expectation()
-        InAppPurchase.handle(queue: queue, transaction: transaction, handler: { result in
+        InAppPurchase.handle(transaction: transaction, handler: { result in
             switch result {
             case .success(let state):
                 XCTAssertEqual(state, .deferred)
@@ -547,7 +543,6 @@ class InAppPurchaseTests: XCTestCase {
     }
 
     func testHandleWhereFailed() {
-        let queue = StubPaymentQueue()
 
         let error = NSError(domain: "test", code: 500, userInfo: nil)
         let payment = StubPayment(productIdentifier: "PRODUCT_001")
@@ -559,7 +554,7 @@ class InAppPurchaseTests: XCTestCase {
         )
 
         let expectation = self.expectation()
-        InAppPurchase.handle(queue: queue, transaction: transaction, handler: { result in
+        InAppPurchase.handle(transaction: transaction, handler: { result in
             switch result {
             case .success:
                 XCTFail()


### PR DESCRIPTION
I fixed a bug that `fallbackHandler` does not handle with `transactionState`.