### PR TITLE
Include the transaction with PaymentState.restored

### DIFF
--- a/Sources/InAppPurchase.swift
+++ b/Sources/InAppPurchase.swift
@@ -38,7 +38,7 @@ final public class InAppPurchase {
     public enum PaymentState {
         case purchased(transaction: PaymentTransaction)
         case deferred
-        case restored
+        case restored(transaction: PaymentTransaction)
     }
 
     public static let `default` = InAppPurchase()

--- a/Sources/InAppPurchase.swift
+++ b/Sources/InAppPurchase.swift
@@ -160,7 +160,7 @@ extension InAppPurchase.PaymentState: Equatable {
         switch (lhs, rhs) {
         case (.purchased(let transaction1), .purchased(let transaction2)): return transaction1.transactionIdentifier == transaction2.transactionIdentifier
         case (.deferred, .deferred): return true
-        case (.restored, .restored): return true
+        case (.restored(let transaction1), .restored(let transaction2)): return transaction1.transactionIdentifier == transaction2.transactionIdentifier
         default: return false
         }
     }

--- a/Sources/Internal/Internal+InAppPurchase.swift
+++ b/Sources/Internal/Internal+InAppPurchase.swift
@@ -70,7 +70,7 @@ extension InAppPurchase {
         case .purchased:
             handler?(.success(.purchased(transaction: Internal.PaymentTransaction(transaction))))
         case .restored:
-            handler?(.success(.restored))
+            handler?(.success(.restored(transaction: Internal.PaymentTransaction(transaction))))
         case .deferred:
             handler?(.success(.deferred))
         case .failed:


### PR DESCRIPTION
Helps with #26 but not a complete solution, as the product IDs are not returned in the `restore` handler.  Rather, you would switch on the payment state in the fallback handler.

```swift
InAppPurchase.default.addTransactionObserver(fallbackHandler: { result in
    switch result {
    case .success(let state):
        switch state {
        case .purchased(let transaction), .restored(let transaction):
            // update the local cache (UserDefaults, keychain, etc.)
        // ...
        }
    // ...
    }
})

InAppPurchase.default.restore()
```