### PR TITLE
Make PaymentState.state and transaction public.

### DIFF
--- a/Sources/InAppPurchase.swift
+++ b/Sources/InAppPurchase.swift
@@ -41,8 +41,8 @@ final public class InAppPurchase {
             case deferred
             case restored
         }
-        let state: State
-        let transaction: PaymentTransaction
+        public let state: State
+        public let transaction: PaymentTransaction
     }
 
     public static let `default` = InAppPurchase()


### PR DESCRIPTION
Hi, with InAppPurchase v2.1.4.
I did validate the transaction which returned by the callback of `addTransactionObserver`.
After v2.3.0, I found I can't do that anymore.


![image](https://user-images.githubusercontent.com/1109143/71502216-4aa77680-28b2-11ea-8050-ac60ed9678b9.png)

It will be work after making state and transaction public.
Thanks.